### PR TITLE
Cater for incomplete authority data in views

### DIFF
--- a/application/helpers/formatting_helper.php
+++ b/application/helpers/formatting_helper.php
@@ -114,6 +114,9 @@ function is_service_valid($authority_type,$service_is_district,$service_is_count
 }
 
 function format_flag($country) {
+  if(empty($country)) {
+    return '';
+  }
   $country_file = strtolower(str_replace(' ','-',$country));
   return '<img class="flag" width="16" height="16" alt="'.$country.'" src="/css/'.$country_file.'.png" />';
 }

--- a/application/views/services/view.php
+++ b/application/views/services/view.php
@@ -57,7 +57,7 @@
       </td>
       <td><?php echo $url->snac; ?></td>
       <td><?php echo format_flag($url->country);?></td>
-      <td><?php echo $url->authority; ?> (<?php echo $url->type; ?>)</td>
+      <td><?php echo $url->authority; ?> (<?php if(empty($url->type)) { echo ' ? '} else { echo $url->type }; ?>)</td>
       <td><?php echo $url->interaction_short.' ('.$url->lgil.')'?></td>
       <td><a href="<?php echo $url->url; ?>" title="<?php echo $url->url; ?>"><?php echo ellipsize($url->url,35, 0.4); ?></a></td>
       <?php if($url->http_status) : ?>


### PR DESCRIPTION
Just noticed that the Food Standards Agency Northern Ireland doesn't appear to have complete data, resulting in (at the foot of each page):
- Broken img links when the country of an authority is unknown (on e.g. http://govuklocal.dafyddvaughan.co.uk/authorities )
- Odd looking parentheses when the authority type is unknown (on e.g. http://govuklocal.dafyddvaughan.co.uk/services/280 )

This addresses those two issues (at least on those pages).
